### PR TITLE
Add generic data preparation

### DIFF
--- a/Preprocessing/data_manipulation.py
+++ b/Preprocessing/data_manipulation.py
@@ -1,0 +1,31 @@
+import pandas as pd
+from sklearn.preprocessing import LabelEncoder
+
+def prepare_data_for_decision_tree(filename):
+    # Load the data into a pandas DataFrame.
+    df = pd.read_csv(filename, delim_whitespace=True, parse_dates=True)
+
+    # Initialize a label encoder.
+    label_encoder = LabelEncoder()
+
+    # Iterate over each column in the DataFrame.
+    for column in df.columns:
+        # If the data type of this column is 'object', it is a categorical feature and needs to be converted.
+        if df[column].dtype == 'object':
+            # Fill missing values with the string 'missing'.
+            df[column].fillna('missing', inplace=True)
+            # Convert the column to numerical values using label encoding.
+            df[column] = label_encoder.fit_transform(df[column])
+        # else:
+        #     # If the data type is not 'object', it is a numerical feature.
+        #     # Fill missing values with the median of the column.
+        #     df[column].fillna(df[column].median(), inplace=True)
+
+    # If 'date' is one of the columns, convert it to numerical features.
+    if 'date' in df.columns:
+        df['year'] = df['date'].dt.year
+        df['month'] = df['date'].dt.month
+        df['day'] = df['date'].dt.day
+        df.drop('date', axis=1, inplace=True)
+
+    return df


### PR DESCRIPTION
Add generic data preparation that get dataset and prepare it for decision tree model, by the following steps:

1. Load the data into a pandas DataFrame.
2. Convert categorical features to numerical values because decision trees in libraries like scikit-learn need numerical values to split nodes.
3. Handle any missing values if necessary.
4. Convert the date to numerical features or extract relevant information from it (like year, month, day) if the date is an important feature for the model.

